### PR TITLE
Update buildout configuration

### DIFF
--- a/profiles/base.cfg
+++ b/profiles/base.cfg
@@ -22,6 +22,7 @@ eggs =
     chaussette
     request_id_middleware
     server_cookie_middleware
+    mock
     ${:package-name}
 index = https://pypi.python.org/simple
 find-links =

--- a/profiles/versions.cfg
+++ b/profiles/versions.cfg
@@ -13,7 +13,7 @@ WebOb = 1.7
 WebTest = 2.0.20
 ZEO = 4.0.0
 ZODB = 4.0.1
-circus = 0.12.1
+circus = 0.14.0
 circus-web = 0.5
 collective.recipe.sphinxbuilder = 0.8.2
 collective.recipe.template = 1.11
@@ -331,10 +331,10 @@ pycrypto = 2.6.1
 grequests = 0.2.0
 
 # Added by buildout at 2015-09-22 13:06:13.920992
-cffi = 1.4.1
-cryptography = 1.2.3
-idna = 2.0
-pyOpenSSL = 0.15.1
+cffi = 1.7
+cryptography = 2.1.4
+idna = 2.1
+pyOpenSSL = 17.5.0
 
 # Required by:
 # cryptography==1.0.1
@@ -436,3 +436,6 @@ plaster = 1.0
 # Required by:
 # pyramid==1.9
 plaster-pastedeploy = 0.4.1
+
+# Added by buildout at 2018-03-28 10:33:23.749170
+asn1crypto = 0.24.0


### PR DESCRIPTION
- circus -> 0.14.0
- add `mock` package

Also `pyOpenSSL` - related package versions were updated.