### PR TITLE
Increment version of `chaussette`

### DIFF
--- a/profiles/versions.cfg
+++ b/profiles/versions.cfg
@@ -87,7 +87,7 @@ certifi = 14.05.14
 # Required by:
 # openprocurement.api==0.6
 # openprocurement.chronograph==0.0
-chaussette = 1.2
+chaussette = 1.3
 
 # Required by:
 # openprocurement.api==0.6
@@ -439,3 +439,14 @@ plaster-pastedeploy = 0.4.1
 
 # Added by buildout at 2018-03-28 10:33:23.749170
 asn1crypto = 0.24.0
+
+# Added by buildout at 2018-04-16 11:15:30.477346
+pyparsing = 2.2.0
+
+# Required by:
+# openprocurement.api==2.4.19+eacore
+isodate = 0.6.0
+
+# Required by:
+# cryptography==1.8.2
+packaging = 17.1


### PR DESCRIPTION
There is `--graceful-shutdown` option in the circus config file, but
this option is supported only from `chaussette-1.3.0`, while version
`1.2` was specified in the `versions.cfg`.

---
[What's new in `chaussette-1.3.0`](https://github.com/circus-tent/chaussette/tree/1.3.0#changelog)